### PR TITLE
Fix Issues 29213

### DIFF
--- a/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
+++ b/app/code/Magento/Backend/Block/Widget/Grid/Column/Filter/Price.php
@@ -194,11 +194,11 @@ class Price extends \Magento\Backend\Block\Widget\Grid\Column\Filter\AbstractFil
         $rate = $this->_getRate($displayCurrency, $this->_getColumnCurrencyCode());
 
         if (isset($value['from'])) {
-            $value['from'] *= $rate;
+            $value['from'] = (float) $value['from'] * $rate;
         }
 
         if (isset($value['to'])) {
-            $value['to'] *= $rate;
+            $value['to'] = (float) $value['to'] * $rate;
         }
 
         $this->prepareRates($displayCurrency);


### PR DESCRIPTION
### Description (*)
If use Magento\Backend\Block\Widget\Grid\Column\Filter\Price::getCondition method and Magento\Backend\Block\Widget\Grid\Column\Filter\Price::getValue() return array with indexes 'from' or 'to' string data, then PHP throw notice exception and Magento break apply filter, redirect to some page 
### Fixed Issues (if relevant)
1. Fixes magento/magento2#29213

### Manual testing scenarios (*)
1. Create Grid Block with deprecated functionality extended class Magento\Backend\Block\Widget\Grid\Extended
2. Add column type price `$this->addColumn( 'total_price', [ 'header' => __('Total Price'), 'index' => 'total_price', 'type' => 'price', 'currency_code' => (string)$this->_scopeConfig ->getValue(Currency::XML_PATH_CURRENCY_BASE), ] );`
3. Apply a filter on this field. Example: '123a'
4. Apply filter price to 123 cost

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
